### PR TITLE
(docs) Edit services endpoint docs

### DIFF
--- a/documentation/status-api/v1/services.markdown
+++ b/documentation/status-api/v1/services.markdown
@@ -6,77 +6,81 @@ canonical: "/puppetserver/latest/status-api/v1/services.html"
 
 [`auth.conf`]: ../../config_file_auth.markdown
 
-The `status` endpoint provides information about the services that Puppet
-Server is running.  As of the 2.6.0 release, the only useful information that
-the endpoint provides is related to memory usage -- basically the same as that
-which the Java MemoryMXBean provides -- and some basic data on process start
-and uptime.  See the
+The `services` endpoint of Puppet Server's Status API provides information about
+services running on Puppet Server. As of Puppet Server 2.6.0, the endpoint provides
+information about memory usage similar to the data produced by the Java MemoryMXBean,
+as well as basic data on the `pupppetserver` process's state and uptime. See the
 [Java MemoryMXBean documentation](https://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryMXBean.html)
-for more information on how to interpret the memory
-information.
+for help interpreting the memory information.
 
-This is currently an experimental feature provided for troubleshooting
-purposes.  The response payload for the `status` endpoint may change without
-prior warning in future release.
+> **Note:** This is an experimental feature provided for troubleshooting
+purposes. In future releases, the `services` endpoint's response payload might
+change without warning.
 
 ## `GET /status/v1/services`
 
 (Introduced in Puppet Server 2.6.0)
 
-### Supported HTTP Methods
+### Supported HTTP methods
 
 GET
 
-### Supported Formats
+### Supported formats
 
 JSON
 
-### Query Parameters
+### Query parameters
 
-* `level` (optional): One of the values listed below. Status information for all
-   registered services will be provided at the requested level of detail.  If
-   not provided the default level is "info".
-  * `critical`: Returns only the bare minimum amount of status information for
-    each service.  Intended to return very quickly and to be suitable for use
-    cases like health checks for a load balancer.
-  * `info`: Typically returns a bit more info than the "critical" level would,
-    for each service.  The specific data that is returned will depend on the
-    implementation details of the services loaded in the application, but should
-    generally be data that is useful for a human to get a quick impression of the
-    health / status of each service.
-  * `debug`: This level can be used to request very detailed status information
-    about a service, typically used by a human for debugging.  Requesting this
-    level of status information may be significantly more expensive than the lower
-    levels, depending on the service.  A common use case would be for a service to
-    provide some detailed aggregate metrics about the performance or resource
-    usage of its subsystems.
+-   `level` (optional): The response includes status information for all
+    registered services at the requested level of detail. Default: `info`. Valid
+    values:
 
-  The information returned for any service at each increasing level of detail
-  should be additive; in other words, "info" should return the same data
-  structure as "critical", but may add additional data in the status field.
-  Likewise, "debug" should return the same data structure as "info", but may add
-  additional information in the status field.
+    -   `critical`: Returns the minimum amount of status information for each
+        service. This level returns data quickly and is suitable for frequently
+        updating uses, such as health checks for a load balancer.
+
+    -   `info`: Returns more info than the `critical` level for each service.
+        The specific data depends on the implementation details of the services
+        loaded in the application, but generally includes enough human-readable
+        data to provide a quick impression of each service's health and status.
+
+    -   `debug`: This level returns status information about a service in enough
+        detail to be suitable for debugging issues with the `puppetserver`
+        process. Depending on the service, this level can be significantly more
+        expensive than lower levels, reduce the process's performance, and
+        generate large amounts of data. This level is suitable for producing
+        aggregate metrics about the performance or resource usage of Puppet
+        Server's subsystems.
+
+    The information returned for any service at each increasing level of detail
+    includes the data from lower levels. In other words, the `info` level returns
+    the same data structure as the `critical` level, and might provide additional
+    data in the `status` field depending on the service. Likewise, the `debug`
+    level returns the same data structure as `info`, and might also add additional
+    information in the `status` field.
 
 ### Response
 
-The response includes information for services that the status service knows
-about.  The service `state` is set as follows:
+The `services` endpoint's response includes information for each service about
+which the Status service is aware. Each service's `state` value is one of the
+following:
 
-* `running`: if and only if all services are running.
-* `error`: if any service reports error.
-* `starting`: if any service reports starting and no service reports error or
-   stopping.
-* `stopping`: if any service reports stopping and no service reports error.
-* `unknown`: if any service reports unknown and no services report error.
+-   `running`, if and only if all services are running
+-   `error` if any service reports an error
+-   `starting` if any service reports that it is starting, and no service reports
+     an error or that it is stopping
+-   `stopping` if any service reports that it is stopping and no service reports
+     an error
+-   `unknown` if any service reports an unknown state and no services report an
+     error
 
-A request made to this endpoint will return one of the following status codes:
- 
-* 200: returned when all services are in `running` state.
-- 404: returned when a requested service is not found.
-- 503: returned when the service state is `unknown`, `error`, `starting`, or
-  `stopping`.
+Requests to this endpoint return one of the following status codes:
 
-### Example response for GET request with `level=debug`
+-   200 when all services are in `running` state.
+-   404 when a requested service is not found.
+-   503 when the service state is `unknown`, `error`, `starting`, or `stopping`
+
+### Example request and response for a debug-level GET request
 
 ~~~
 GET /status/v1/services?level=debug
@@ -116,12 +120,15 @@ Content-Type: application/json
 
 ### Authorization
 
-Requests made to the status endpoint are not authorized by either the
-Trapperkeeper-based [`auth.conf`] feature or the older Ruby-based authorization
-process.  For more information about the Puppet Server authorization process and
-configuration settings, see the [`auth.conf` documentation][`auth.conf`].
+Requests to the `services` endpoint are not authorized by either the
+[Trapperkeeper-based authorization process][`auth.conf`] introduced in Puppet
+Server 2.3.0, or the deprecated Ruby-based authorization process. For more
+information about the supported and deprecated Puppet Server authorization
+processes and configuration settings, see the
+[`auth.conf` documentation][`auth.conf`].
 
-Unless the `client-auth` setting is set to `required` for the
-webserver, a client should be permitted to make a request to this endpoint via
-SSL with or without the use of a client certificate.  See [Configuring the Webserver Service](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/jetty-config.md#client-auth)
+Unless the `client-auth` setting is set to `required` for the webserver, a
+client should be permitted to make a request to this endpoint via SSL with or
+without the use of a client certificate. See
+[Configuring the Webserver Service](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/jetty-config.md#client-auth)
 for more information on the `client-auth` setting.


### PR DESCRIPTION
-   Some references to the endpoint call it the `status` endpoint. Changed these to `services`.
-   Used sentence case in headings due to recent changes in the Puppet style guide.
-   Adjusted the list Markdown for clarity.
-   Adjusted and expanded wording around tk-auth/`auth.conf`
